### PR TITLE
Add potentially annoying javadoc workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build
 
 on:
   push:
-  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -2,7 +2,6 @@ name: Javadoc
 
 on:
   push:
-  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,0 +1,18 @@
+name: Javadoc
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    container: wpilib/roborio-cross-ubuntu:2024-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Grant execute permission
+        run: chmod +x gradlew
+      - name: Create Javadoc
+        run: ./gradlew javadoc

--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -2,7 +2,6 @@ name: Spotless (Formatting)
 
 on:
   push:
-  pull_request:
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -116,4 +116,5 @@ tasks.named('javadoc') {
     exclude '**/*TunerConstants.java'
     exclude '**/LimelightHelpers.java'
     exclude '**/Main.java'
+    options.encoding = 'UTF-8'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -110,3 +110,10 @@ spotless {
         eclipse().configFile('.vscode/java-formatter.xml')
     }
 }
+
+tasks.named('javadoc') {
+    options.addStringOption('Xwerror', '-Xwerror')
+    exclude '**/*TunerConstants.java'
+    exclude '**/LimelightHelpers.java'
+    exclude '**/Main.java'
+}

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -14,12 +14,21 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import frc.robot.zippy.ZippyContainer;
 
+/**
+ * The main robot class. This is where the robot code starts and ends. This
+ * class is responsible for creating the robot-specific container and running
+ * the robot code.
+ */
 public class Robot extends TimedRobot
 {
     private Command m_autonomousCommand;
 
     private final NFRRobotContainer m_robotContainer;
 
+    /**
+     * The robot container is the main class for the robot. It is responsible for
+     * creating the robot-specific container and running the robot code.
+     */
     public Robot()
     {
         NFRRobotChooser chooser = new NFRRobotChooser(() -> new ZippyContainer(), Map.of());

--- a/src/main/java/frc/robot/Telemetry.java
+++ b/src/main/java/frc/robot/Telemetry.java
@@ -20,6 +20,9 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj.util.Color8Bit;
 
+/**
+ * A Phoenix6 generated class to log telemetry in hoot files
+ */
 public class Telemetry
 {
     private final double MaxSpeed;
@@ -85,6 +88,8 @@ public class Telemetry
     /**
      * Accept the swerve drive state and telemeterize it to SmartDashboard and
      * SignalLogger.
+     * 
+     * @param state The swerve drive state to telemeterize
      */
     public void telemeterize(SwerveDriveState state)
     {

--- a/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -215,7 +215,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
      * Returns a command that applies the specified control request to this swerve
      * drivetrain.
      *
-     * @param request Function returning the request to apply
+     * @param requestSupplier Function returning the request to apply
      * @return Command to run
      */
     public Command applyRequest(Supplier<SwerveRequest> requestSupplier)

--- a/src/main/java/frc/robot/zippy/ZippyContainer.java
+++ b/src/main/java/frc/robot/zippy/ZippyContainer.java
@@ -18,6 +18,10 @@ import frc.robot.Telemetry;
 import frc.robot.subsystems.CommandSwerveDrivetrain;
 import frc.robot.zippy.generated.ZippyTunerConstants;
 
+/**
+ * This is the main robot container for the Zippy robot. It contains the robot's
+ * subsystems, commands, and OI (operator interface) bindings.
+ */
 public class ZippyContainer implements NFRRobotContainer
 {
     private double MaxSpeed = ZippyTunerConstants.kSpeedAt12Volts.in(MetersPerSecond); // kSpeedAt12Volts desired top
@@ -25,11 +29,20 @@ public class ZippyContainer implements NFRRobotContainer
 
     private final Telemetry logger = new Telemetry(MaxSpeed);
 
+    /**
+     * This is the swerve drivetrain subsystem for the Zippy robot. It is
+     * responsible for controlling the robot's movement and handling the swerve
+     * drive mechanism.
+     */
     public final CommandSwerveDrivetrain drivetrain = ZippyTunerConstants.createDrivetrain();
 
     /* Path follower */
     private final SendableChooser<Command> autoChooser;
 
+    /**
+     * Creates a new ZippyContainer. This is where the robot's subsystems, commands,
+     * and OI (operator interface) bindings are created.
+     */
     public ZippyContainer()
     {
         autoChooser = AutoBuilder.buildAutoChooser("Tests");

--- a/src/main/java/frc/robot/zippy/ZippyOI.java
+++ b/src/main/java/frc/robot/zippy/ZippyOI.java
@@ -1,7 +1,17 @@
 package frc.robot.zippy;
 
+/**
+ * This is the OI (operator interface) class for the Zippy robot. It is
+ * responsible for binding the robot's subsystems to the operator interface (OI)
+ * controls.
+ */
 public class ZippyOI
 {
+    /**
+     * Binds the robot's subsystems to the operator interface (OI) controls.
+     * 
+     * @param container The ZippyContainer instance to bind the OI to.
+     */
     public void bind(ZippyContainer container)
     {
 

--- a/src/main/java/org/northernforce/util/NFRRobotChooser.java
+++ b/src/main/java/org/northernforce/util/NFRRobotChooser.java
@@ -12,8 +12,8 @@ import edu.wpi.first.wpilibj.RobotController;
  */
 public class NFRRobotChooser
 {
-    protected final Supplier<NFRRobotContainer> defaultRobot;
-    protected final Map<String, Supplier<NFRRobotContainer>> otherRobots;
+    private final Supplier<NFRRobotContainer> defaultRobot;
+    private final Map<String, Supplier<NFRRobotContainer>> otherRobots;
 
     /**
      * Creates a new robot chooser.


### PR DESCRIPTION
For some reason, every public or protected FIELD in addition to method and class must have javadocs. I mean, I get why. It just might be a bit painful.