### PR TITLE
Add S3 no-shoot middle collect auto

### DIFF
--- a/src/main/deploy/pathplanner/autos/S3-NOSHOOT-MIDDLE-COLLECT-SHOOT.auto
+++ b/src/main/deploy/pathplanner/autos/S3-NOSHOOT-MIDDLE-COLLECT-SHOOT.auto
@@ -1,0 +1,145 @@
+{
+  "version": "2025.0",
+  "command": {
+    "type": "sequential",
+    "data": {
+      "commands": [
+        {
+          "type": "deadline",
+          "data": {
+            "commands": [
+              {
+                "type": "path",
+                "data": {
+                  "pathName": "S3-NZR"
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "Intake"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "deadline",
+          "data": {
+            "commands": [
+              {
+                "type": "path",
+                "data": {
+                  "pathName": "NZR-NZM"
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "Intake"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "deadline",
+          "data": {
+            "commands": [
+              {
+                "type": "path",
+                "data": {
+                  "pathName": "NZM-SR"
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "StopIntake"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "deadline",
+          "data": {
+            "commands": [
+              {
+                "type": "wait",
+                "data": {
+                  "waitTime": 2.0
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "Shoot"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "StopShoot"
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "SR-NZR"
+          }
+        },
+        {
+          "type": "deadline",
+          "data": {
+            "commands": [
+              {
+                "type": "path",
+                "data": {
+                  "pathName": "NZR-NZM"
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "Intake"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "deadline",
+          "data": {
+            "commands": [
+              {
+                "type": "path",
+                "data": {
+                  "pathName": "NZM-SR"
+                }
+              },
+              {
+                "type": "named",
+                "data": {
+                  "name": "StopIntake"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "named",
+          "data": {
+            "name": "Shoot"
+          }
+        }
+      ]
+    }
+  },
+  "resetOdom": true,
+  "folder": null,
+  "choreoAuto": false
+}

--- a/src/main/java/frc/robot/lobby/LobbyContainer.java
+++ b/src/main/java/frc/robot/lobby/LobbyContainer.java
@@ -207,6 +207,8 @@ public class LobbyContainer implements NFRRobotContainer
         autoUtil.bindAuto("S2-DEPOT", new PathPlannerAuto("S2-DEPOT"));
         autoUtil.bindAuto("S1-SHOOT", new PathPlannerAuto("S1-SHOOT"));
         autoUtil.bindAuto("S3-SHOOT", new PathPlannerAuto("S3-SHOOT"));
+        autoUtil.bindAuto("S3-NOSHOOT-MIDDLE-COLLECT-SHOOT",
+                new PathPlannerAuto("S3-NOSHOOT-MIDDLE-COLLECT-SHOOT"));
         autoUtil.bindAuto("S1-SHOOT-DEPOT", new PathPlannerAuto("S1-SHOOT-DEPOT"));
         autoUtil.bindAuto("S1-SIMPLE", new SimpleAuto(this, new PathPlannerAuto("S1-SHOOT").getStartingPose()));
         autoUtil.bindAuto("S3-SIMPLE", new SimpleAuto(this, new PathPlannerAuto("S3-SHOOT").getStartingPose()));


### PR DESCRIPTION
## Summary
- add a PathPlanner auto that mirrors S3-SHOOT without the opening wait/shoot/stop group
- bind the new auto in the lobby auto list

## Testing
- not run (not requested)